### PR TITLE
Fixed #46: change npm run start

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ npm install
 - Now the basis of the project is here and can already be viewed by running:
 
 ```ssh
-npm run start
+npm run dev
 ```
 
 - You may view the various endpoints by opening `localhost:8000` in your browser and appending the desired route


### PR DESCRIPTION
Fixed issue #46: Changed "npm run start" to "npm run dev" in installation section of readme.