### PR TITLE
UUID generation with short-crypt and data from cheerio as array

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "axios": "^0.26.1",
         "cheerio": "^1.0.0-rc.10",
         "express": "^4.17.3",
-        "express-rate-limit": "^6.4.0"
+        "express-rate-limit": "^6.4.0",
+        "short-crypt": "^1.0.25"
       },
       "devDependencies": {
         "all-contributors-cli": "^6.20.0",
@@ -1124,6 +1125,11 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "node_modules/@types/node": {
       "version": "17.0.35",
@@ -2795,6 +2801,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/hi-base32": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/hi-base32/-/hi-base32-0.5.1.tgz",
+      "integrity": "sha512-EmBBpvdYh/4XxsnUybsPag6VikPYnN30td+vQk+GI3qpahVEG9+gTkG0aXVxTjBqQ5T6ijbWIu77O+C5WFWsnA=="
+    },
+    "node_modules/hi-base64": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/hi-base64/-/hi-base64-0.2.1.tgz",
+      "integrity": "sha512-qNNwcztb8B9krbWBtYVH8motgSCBLhbCXE6xOSjFFxeP5Z4gd9RLYs6bv1qd4Y17z3v7+h1fn8RQmAi60AMvQQ=="
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -4013,6 +4029,11 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/long": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
+      "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
+    },
     "node_modules/lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -5064,6 +5085,20 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/short-crypt": {
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/short-crypt/-/short-crypt-1.0.25.tgz",
+      "integrity": "sha512-K9NBNQFVWue53MdSknU4bComwQ3gpHhfe7CLPPuGW79/XRjQL5a8abYfsEHbYbA8UgPDOt/E1UOSWuAtdq5e2A==",
+      "dependencies": {
+        "@types/long": "^4.0.2",
+        "hi-base32": "^0.5.0",
+        "hi-base64": "^0.2.1",
+        "long": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/side-channel": {
@@ -6703,6 +6738,11 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+    },
     "@types/node": {
       "version": "17.0.35",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
@@ -7965,6 +8005,16 @@
       "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
       "dev": true
     },
+    "hi-base32": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/hi-base32/-/hi-base32-0.5.1.tgz",
+      "integrity": "sha512-EmBBpvdYh/4XxsnUybsPag6VikPYnN30td+vQk+GI3qpahVEG9+gTkG0aXVxTjBqQ5T6ijbWIu77O+C5WFWsnA=="
+    },
+    "hi-base64": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/hi-base64/-/hi-base64-0.2.1.tgz",
+      "integrity": "sha512-qNNwcztb8B9krbWBtYVH8motgSCBLhbCXE6xOSjFFxeP5Z4gd9RLYs6bv1qd4Y17z3v7+h1fn8RQmAi60AMvQQ=="
+    },
     "html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -8898,6 +8948,11 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "long": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
+      "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
+    },
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -9675,6 +9730,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
+    },
+    "short-crypt": {
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/short-crypt/-/short-crypt-1.0.25.tgz",
+      "integrity": "sha512-K9NBNQFVWue53MdSknU4bComwQ3gpHhfe7CLPPuGW79/XRjQL5a8abYfsEHbYbA8UgPDOt/E1UOSWuAtdq5e2A==",
+      "requires": {
+        "@types/long": "^4.0.2",
+        "hi-base32": "^0.5.0",
+        "hi-base64": "^0.2.1",
+        "long": "^5.2.0"
+      }
     },
     "side-channel": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "axios": "^0.26.1",
     "cheerio": "^1.0.0-rc.10",
     "express": "^4.17.3",
-    "express-rate-limit": "^6.4.0"
+    "express-rate-limit": "^6.4.0",
+    "short-crypt": "^1.0.25"
   },
   "engines": {
     "node": "16.x",

--- a/src/controller/api/newsAPIController.js
+++ b/src/controller/api/newsAPIController.js
@@ -1,22 +1,26 @@
 const axios = require('axios');
 const sources = require('../../data/sources.json');
+const sc = require('short-crypt');
 const getDataFromCheerio = require('../../utils/getDataFromCheerio');
 let articles = {};
 
 sources.forEach(async (source) => {
   try {
     const response = await axios.get(source.site);
-    const { url, title } = getDataFromCheerio(response.data);
+    const returnedArticles = getDataFromCheerio(response.data);
 
-    articles[url] = {
-      title,
-      url: source.base + url,
-      source: source.name,
-    };
-  } catch (error) {
-    console.log({ error });
-    return;
-  }
+    returnedArticles.forEach(async (returned) => {
+
+      articles[new sc(returned.url).encryptToQRCodeAlphanumeric(returned.url).slice(0, 10)] = {
+        title: returned.title,
+        url: source.base + returned.url,
+        source: source.name,
+      };
+    })
+    } catch (error) {
+      console.log({ error });
+      return;
+    }
 });
 
 const controller = {

--- a/src/controller/api/newsAPIController.js
+++ b/src/controller/api/newsAPIController.js
@@ -1,6 +1,6 @@
 const axios = require('axios');
 const sources = require('../../data/sources.json');
-const sc = require('short-crypt');
+const sc = require('short-crypt'); // new
 const getDataFromCheerio = require('../../utils/getDataFromCheerio');
 let articles = {};
 
@@ -9,9 +9,9 @@ sources.forEach(async (source) => {
     const response = await axios.get(source.site);
     const returnedArticles = getDataFromCheerio(response.data);
 
-    returnedArticles.forEach(async (returned) => {
+    returnedArticles.forEach(async (returned) => { // now we have an array of multiple article's data to iterate through
 
-      articles[new sc(returned.url).encryptToQRCodeAlphanumeric(returned.url).slice(0, 10)] = {
+      articles[new sc(returned.url).encryptToQRCodeAlphanumeric(returned.url).slice(0, 10)] = { // use short-crypt to "hash" the url which works as unique ID
         title: returned.title,
         url: source.base + returned.url,
         source: source.name,

--- a/src/data/keywords.js
+++ b/src/data/keywords.js
@@ -2,8 +2,15 @@
 module.exports = keywords = [
   "green energy",
   "energy price",
+  "energy prices",
   "energy firms",
   "renewable energy",
   "energy company",
   "energy tax",
+  "energy bill",
+  "energy resources",
+  "electricity bill",
+  "gas bill",
+  "electricity costs",
+  "energy"
 ];

--- a/src/data/keywords.js
+++ b/src/data/keywords.js
@@ -7,10 +7,10 @@ module.exports = keywords = [
   "renewable energy",
   "energy company",
   "energy tax",
-  "energy bill",
-  "energy resources",
-  "electricity bill",
-  "gas bill",
-  "electricity costs",
-  "energy"
+  "energy bill", // new
+  "energy resources", // new
+  "electricity bill", // new
+  "gas bill", // new
+  "electricity costs", // new
+  "energy" // new
 ];

--- a/src/utils/getDataFromCheerio.js
+++ b/src/utils/getDataFromCheerio.js
@@ -5,8 +5,9 @@ const keywords = require('../../src/data/keywords');
 function getDataFromCheerio(html) {
   if (!html) throw new Error('There is nothing to load here');
 
-  let title = '';
-  let url = '';
+  // let title = '';
+  // let url = '';
+  let returnedArticles = [];
 
   const $ = cheerio.load(html);
   keywords.forEach((keyword) => {
@@ -19,10 +20,13 @@ function getDataFromCheerio(html) {
       );
 
       url = $(this).attr('href');
+
+      returnedArticles.push({"title": title, "url": url})
     });
   });
 
-  return { url, title };
+  console.log(returnedArticles)
+  return returnedArticles;
 }
 
 module.exports = getDataFromCheerio;

--- a/src/utils/getDataFromCheerio.js
+++ b/src/utils/getDataFromCheerio.js
@@ -7,10 +7,12 @@ function getDataFromCheerio(html) {
 
   // let title = '';
   // let url = '';
+
+  // Make an empty list
   let returnedArticles = [];
 
   const $ = cheerio.load(html);
-  keywords.forEach((keyword) => {
+  keywords.forEach((keyword) => { // search for each given keyword from keyword file/array
     $("a:contains('" + keyword + "')", html).each(function () {
       title = getTitle(
         $(this)
@@ -21,12 +23,11 @@ function getDataFromCheerio(html) {
 
       url = $(this).attr('href');
 
-      returnedArticles.push({"title": title, "url": url})
+      returnedArticles.push({"title": title, "url": url}) // add each page search results to list
     });
   });
 
-  console.log(returnedArticles)
-  return returnedArticles;
+  return returnedArticles; // return full list
 }
 
 module.exports = getDataFromCheerio;


### PR DESCRIPTION
# A few issues handled together

Closes #59 - New data type being created and returned by `getDataFromCheerio.js` removes the possibility of an empty string

Closes #60 - before, only the last iteration was passed back to the controller. Now a list is constructed and passed back.

Closes #44 - still using `url` as the key, but hashing it and then using `String.slice(0, 10)` to return the first 10 chars as a means of UUID. This way it retains it's safeguard against repeated articles.

## Awaiting review from
@TAKANOME-DEV 
@dbsaw 
@SquatCub