### PR TITLE
Extract og:image link from html body and add to return object

### DIFF
--- a/src/controller/api/newsAPIController.js
+++ b/src/controller/api/newsAPIController.js
@@ -15,6 +15,7 @@ sources.forEach(async (source) => {
         title: returned.title,
         url: source.base + returned.url,
         source: source.name,
+        image: returned.image
       };
     })
     } catch (error) {

--- a/src/controller/api/newsAPIController.js
+++ b/src/controller/api/newsAPIController.js
@@ -1,7 +1,8 @@
 const axios = require('axios');
 const sources = require('../../data/sources.json');
-const sc = require('short-crypt'); // new
+const sc = require('short-crypt');
 const getDataFromCheerio = require('../../utils/getDataFromCheerio');
+const defaultImage = 'https://raw.githubusercontent.com/MizouziE/energy-prices-api/master/public/img/energy-prices-api-socials.png'
 let articles = {};
 
 sources.forEach(async (source) => {
@@ -15,7 +16,7 @@ sources.forEach(async (source) => {
         title: returned.title,
         url: source.base + returned.url,
         source: source.name,
-        image: returned.image
+        image: returned.image ?? defaultImage
       };
     })
     } catch (error) {
@@ -44,13 +45,17 @@ const controller = {
 
     try {
       const response = await axios.get(sourceSite);
-      const { url, title } = getDataFromCheerio(response.data);
+      const returnedArticlesSingle = getDataFromCheerio(response.data);
 
-      singleSourceArticles[url] = {
-        title,
-        url: sourceBase + url,
-        source: sourceName,
-      };
+      returnedArticlesSingle.forEach(async (returnedSingle) => {
+        singleSourceArticles[new sc(returnedSingle.url).encryptToQRCodeAlphanumeric(returnedSingle.url).slice(0, 10)] = {
+          title: returnedSingle.title,
+          url: sourceBase + returnedSingle.url,
+          source: sourceName,
+          image: returnedSingle.image ?? defaultImage
+        };
+      })
+
 
       return res.json(singleSourceArticles);
     } catch (error) {

--- a/src/server.js
+++ b/src/server.js
@@ -8,10 +8,10 @@ const rateLimit = require("express-rate-limit");
 function createServer() {
   const app = express();
 
-  // set up rate limiter: maximum of ten requests per minute
+  // set up rate limiter: maximum of 60 requests per minute
   const limiter = rateLimit({
     windowMs: 1 * 60 * 1000, // 1 minute
-    max: 10,
+    max: 60, // 1 requeest per second
   });
 
   // apply rate limiter to all requests

--- a/src/utils/getDataFromCheerio.js
+++ b/src/utils/getDataFromCheerio.js
@@ -22,8 +22,9 @@ function getDataFromCheerio(html) {
       );
 
       url = $(this).attr('href');
+      ogImageLink = $.html().match(/<(?<Tag_Name>meta property="og:image)\b[^>]*?\b(?<URL_Type>(content))\s*=\s*(?:"(?<URL>(?:\\"|[^"])*)"|')/).groups.URL
 
-      returnedArticles.push({"title": title, "url": url}) // add each page search results to list
+      returnedArticles.push({"title": title, "url": url, "image": ogImageLink}) // add each page search results to list
     });
   });
 

--- a/src/utils/getDataFromCheerio.js
+++ b/src/utils/getDataFromCheerio.js
@@ -22,7 +22,8 @@ function getDataFromCheerio(html) {
       );
 
       url = $(this).attr('href');
-      ogImageLink = $.html().match(/<(?<Tag_Name>meta property="og:image)\b[^>]*?\b(?<URL_Type>(content))\s*=\s*(?:"(?<URL>(?:\\"|[^"])*)"|')/).groups.URL
+
+      ogImageLink = $('head').find('meta[property*="og:image"]').attr('content') // returns og:image from parent site
 
       returnedArticles.push({"title": title, "url": url, "image": ogImageLink}) // add each page search results to list
     });


### PR DESCRIPTION
# Image inclusion with article object

I have used a rather complex regex match function to extract the link to the article's `og:image` from the head

It does come back, but it needs validation/sanitization a little further.

Feel free to take a look and see if you can add to it or improve it in some way.

Closes #16 