### PR TITLE
Max requests limit edited

### DIFF
--- a/src/data/sources.json
+++ b/src/data/sources.json
@@ -33,5 +33,10 @@
     "name": "Reuters",
     "site": "https://www.reuters.com/business/energy/",
     "base": "https://www.reuters.com"
+  },
+  {
+    "name": "Washington Post",
+    "site": "https://www.washingtonpost.com/energy/",
+    "base": "https://www.washingtonpost.com/"
   }
 ]


### PR DESCRIPTION
# Description
### What did I do?
This PR is related to issue #88, I made a research about the [follow-redirects](https://www.npmjs.com/package/follow-redirects) module implemented in this project to solve the following bug:
![image](https://user-images.githubusercontent.com/69327429/177227977-7169fc57-b44b-48b0-909d-f3c3630e6baa.png)
_"When running the scraper locally, one of the newer sources triggered an Error [ERR_FR_TOO_MANY_REDIRECTS]: Maximum number of redirects exceeded."_

### How to solve it:
After reading the follow-redirects documentation and testing locally the project I found out that the module provides default options for different scenarios while making requests, in this case, the two options that are involved in the bug are:

- maxRedirects – sets the maximum number of allowed redirects; if exceeded, an error will be emitted.
- maxBodyLength – sets the maximum size of the request body; if exceeded, an error will be emitted.

**Default values:**
maxRedirects = 21.
maxBodyLength = 10MB (10 * 1024 * 1024).

To solve the bug it's necessary to edit the default values of the options on the `./node_modules/follow-redirects/index.js`.
First I added the source that triggered the bug:
<img width="458" alt="Screen Shot 2022-07-04 at 19 00 13" src="https://user-images.githubusercontent.com/69327429/177228452-2fe1194b-533c-4efb-9051-31a50f0f2856.png">
Then, I changed the values of the options to be able to have more redirects and avoid these kinds of bugs while scrapping sites.
<img width="747" alt="Screen Shot 2022-07-04 at 19 11 30" src="https://user-images.githubusercontent.com/69327429/177228448-24c533f8-7f38-41cf-b1f2-dd649580f9f0.png">

**Changed values:**
maxRedirects = 84.
maxBodyLength = 20MB (20 * 1024 * 1024).


