### PR TITLE
middleware handles non-existing sources

### DIFF
--- a/src/middlewares/existingSourceMiddleware.js
+++ b/src/middlewares/existingSourceMiddleware.js
@@ -1,10 +1,11 @@
 const sources = require('../data/sources.json');
 const path = require('path');
-const eSources = sources.map((source) => source.name); //Existing sources
+const existingSources = sources.map((source) => source.name);
 
+//Finds sourceId match within existingSources, if not, return 404 page not found.
 function existingSourceMiddleware(req, res, next) {
   const sourceId = req.params.sourceId;
-  const sourceFound = eSources.filter(
+  const sourceFound = existingSources.filter(
     (source) => source.toLowerCase().replace(/ /g, '') === sourceId
   );
   if (sourceFound.length === 0) {

--- a/src/middlewares/existingSourceMiddleware.js
+++ b/src/middlewares/existingSourceMiddleware.js
@@ -1,0 +1,16 @@
+const sources = require('../data/sources.json');
+const path = require('path');
+const eSources = sources.map((source) => source.name); //Existing sources
+
+function existingSourceMiddleware(req, res, next) {
+  const sourceId = req.params.sourceId;
+  const sourceFound = eSources.filter(
+    (source) => source.toLowerCase().replace(/ /g, '') === sourceId
+  );
+  if (sourceFound.length === 0) {
+    return res.status(404).sendFile(path.resolve('./src/views/not-found.html'));
+  }
+  next();
+}
+
+module.exports = existingSourceMiddleware;

--- a/src/routes/api/news.js
+++ b/src/routes/api/news.js
@@ -1,8 +1,10 @@
 const express = require('express');
 const controller = require('../../controller/api/newsAPIController');
 const router = express.Router();
+//Middlewares
+const existingSourceMiddleware = require('../../middlewares/existingSourceMiddleware');
 
 router.get('/', controller.getNews);
-router.get('/:sourceId', controller.getNewsBySource);
+router.get('/:sourceId', existingSourceMiddleware, controller.getNewsBySource);
 
 module.exports = router;


### PR DESCRIPTION
This PR solves #77
I created a new folder for future middlewares which includes `existingSourceMiddleware.js`. This middleware acts as a filter between existing and non-existing news sources. What I did was, basically, I checked the list of sources and managed to create a function that finds a match with the required source, if it doesn't then proceed to redirect to a 404 not-found page.

@MizouziE, I'd appreciate it if you could review the changes or any comments about the PR. 