### PR TITLE
moved washington post to new json file

### DIFF
--- a/src/data/problematic-sources.json
+++ b/src/data/problematic-sources.json
@@ -1,0 +1,7 @@
+[  
+  {
+    "name": "Washington Post",
+    "site": "https://www.washingtonpost.com/",
+    "base": ""
+  }
+]

--- a/src/data/sources.json
+++ b/src/data/sources.json
@@ -50,11 +50,6 @@
     "base": ""
   },
   {
-    "name": "Washington Post",
-    "site": "https://www.washingtonpost.com/",
-    "base": ""
-  },
-  {
     "name": "ABC News",
     "site": "https://abcnews.go.com/",
     "base": ""


### PR DESCRIPTION
Too many problems came from the washington post and I want to update the live site version as it's becoming quite a nice API.

I've temporarily removed it as it caused the server to crash.